### PR TITLE
feat: route universal connector auth to its own endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,9 @@ const refold = new Refold({ token?: string, baseUrl?: string })
 
 **Connection:**
 - `connect({ slug, type?, payload?, grantType?, autoClose?, timeout? }): Promise<boolean>` — Connect app (OAuth2 redirect popup, OAuth2 client-credentials/M2M, or key-based POST). `grantType` (an exported `GrantType`) selects the OAuth transport: `client_credentials` submits the fields to the server and returns without opening a window; omit (or a redirect grant) uses the popup flow. Passing `grantType: GrantType.ClientCredentials` routes to the OAuth path even when a payload is present. `autoClose` (default `true`) closes the OAuth popup on success; `timeout` (default 5 minutes, `0` to wait indefinitely) caps the OAuth popup wait. `autoClose`/`timeout` apply only to the redirect popup flow. Param type: exported `ConnectParams` (extends `OAuthParams`).
-- `disconnect(slug, type?): Promise<unknown>` — Disconnect app
+- `disconnect(slug, type?, kind?): Promise<unknown>` — Disconnect app
+
+**Universal connectors:** connectors (`Application.kind === "universal_connector"`) authenticate through their own endpoints under `/api/v1/auth-service/f-sdk/universal-connector/:slug` — `integrate` (OAuth), `save-credentials` (key-based), `revoke` (disconnect) — instead of the native/custom app routes. `connect()`/`disconnect()` route on `kind`: pass it (an exported `ConnectorKind`, from the app object) to skip the lookup, or omit it and the SDK resolves the kind via `getApp(slug)`. A failed lookup falls back to the native path so an unrelated outage can't misroute a native connect.
 
 **Configuration:**
 - `config(payload): Promise<Config>` — Create/get config

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,6 +231,7 @@
       "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -268,6 +269,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refoldai/refold-js",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Refold frontend SDK",
   "main": "./refold.js",
   "typings": "./refold.d.ts",

--- a/refold.d.ts
+++ b/refold.d.ts
@@ -52,7 +52,13 @@ export interface Application {
     grant_type?: GrantType;
     /** The supported auth types for the application, and the fields required from the user to connect the application. */
     auth_type_options?: {
-        [key in AuthType]: InputField[];
+        /**
+         * The fields required from the user to connect the application, keyed by auth
+         * type. Native apps use {@link AuthType} (`oauth2` / `keybased`); universal
+         * connectors key by their own supported types (`api_key`, `basic_auth`,
+         * `bearer_token`, `oauth2`) and may offer several for the user to choose from.
+         */
+        [authType: string]: InputField[];
     };
     /** The list of connected accounts for this application */
     connected_accounts?: {
@@ -141,10 +147,22 @@ export interface KeyBasedParams {
      * skip the lookup; omit it and the SDK resolves the kind from the app itself.
      */
     kind?: ConnectorKind;
+    /**
+     * The auth type being submitted, as named by the application's
+     * {@link Application.auth_type_options}. Universal connectors distinguish
+     * `api_key` / `basic_auth` / `bearer_token`, so a connector offering more than one
+     * cannot be resolved from the credentials alone.
+     */
+    authType?: string;
 }
 export interface ConnectParams extends OAuthParams {
-    /** The authentication type to use. If not provided, it defaults to `keybased` if payload is provided, otherwise `oauth2`. */
-    type?: AuthType;
+    /**
+     * The authentication type to use — an {@link AuthType} for native applications, or
+     * one of a universal connector's own types (a key of
+     * {@link Application.auth_type_options}). If not provided, it defaults to `keybased`
+     * when a payload is given, otherwise `oauth2`.
+     */
+    type?: AuthType | string;
 }
 /** The payload object for config. */
 export interface ConfigPayload {

--- a/refold.d.ts
+++ b/refold.d.ts
@@ -16,9 +16,17 @@ export declare enum GrantType {
     ClientCredentials = "client_credentials"
 }
 /** An application in Refold. */
+/**
+ * What kind of connector an application is. Universal connectors are configured in
+ * Refold rather than shipped as native integrations, and authenticate through their
+ * own endpoints — {@link Refold.connect} and {@link Refold.disconnect} route on this.
+ */
+export type ConnectorKind = "native" | "custom" | "universal_connector";
 export interface Application {
     /** Application ID */
     app_id: string;
+    /** Whether this is a native app, a custom app, or a universal connector. */
+    kind?: ConnectorKind;
     /**The application name. */
     name: string;
     /**The application description. */
@@ -106,6 +114,12 @@ export interface OAuthParams {
     /** The key value pairs of auth data. */
     payload?: Record<string, string>;
     /**
+     * The connector kind (from the app object's {@link Application.kind}). Universal
+     * connectors authenticate through their own endpoints, so pass this to skip the
+     * lookup. Omit it and the SDK resolves the kind from the app itself.
+     */
+    kind?: ConnectorKind;
+    /**
      * The application's OAuth grant (from the app object). Pass
      * {@link GrantType.ClientCredentials} for machine-to-machine connectors so
      * their fields are submitted to the server and no browser window is opened.
@@ -122,6 +136,11 @@ export interface KeyBasedParams {
     slug: string;
     /** The key value pairs of auth data. */
     payload?: Record<string, string>;
+    /**
+     * The connector kind (from the app object's {@link Application.kind}). Pass it to
+     * skip the lookup; omit it and the SDK resolves the kind from the app itself.
+     */
+    kind?: ConnectorKind;
 }
 export interface ConnectParams extends OAuthParams {
     /** The authentication type to use. If not provided, it defaults to `keybased` if payload is provided, otherwise `oauth2`. */
@@ -413,6 +432,16 @@ declare class Refold {
      * @returns {Promise<Application[]>} The list of applications.
      */
     getApps(): Promise<Application[]>;
+    /** Base path for a universal connector's own auth endpoints. */
+    private universalConnectorUrl;
+    /**
+     * Whether a slug is a universal connector. Trusts an explicitly supplied `kind`
+     * (no request); otherwise resolves it from the app. A failed lookup falls back to
+     * `false` so an unrelated outage can't turn a native connect into a wrong-endpoint
+     * call — the native path then reports the real error.
+     * @private
+     */
+    private isUniversalConnector;
     /**
      * Starts the connect flow for the specified application against `/integrate`.
      *
@@ -460,14 +489,15 @@ declare class Refold {
      * @returns A promise that resolves to true if the connection was successful, otherwise false.
      * @throws Throws an error if the authentication type is invalid or the connection fails.
      */
-    connect({ slug, type, payload, grantType, autoClose, timeout, }: ConnectParams): Promise<boolean>;
+    connect({ slug, type, payload, grantType, kind, autoClose, timeout, }: ConnectParams): Promise<boolean>;
     /**
      * Disconnect the specified application and remove any associated data from Refold.
      * @param {String} slug The application slug.
      * @param {AuthType} [type] The authentication type to use. If not provided, it'll remove all the connected accounts.
+     * @param {ConnectorKind} [kind] The connector kind (from the app object). Pass it to skip the lookup.
      * @returns {Promise<unknown>}
      */
-    disconnect(slug: string, type?: AuthType): Promise<unknown>;
+    disconnect(slug: string, type?: AuthType, kind?: ConnectorKind): Promise<unknown>;
     /**
      * Returns the specified config, or creates one if it doesn't exist.
      * @param {ConfigPayload} payload The payload object for config.

--- a/refold.d.ts
+++ b/refold.d.ts
@@ -5,6 +5,18 @@ export declare enum AuthType {
     OAuth2 = "oauth2",
     KeyBased = "keybased"
 }
+/**
+ * The auth types a universal connector can offer, as keyed in
+ * {@link Application.auth_type_options}. A native application is only ever an
+ * {@link AuthType}; a connector names its own and may support several, so the caller has
+ * to say which one it is submitting.
+ */
+export declare enum ConnectorAuthType {
+    OAuth2 = "oauth2",
+    ApiKey = "api_key",
+    BasicAuth = "basic_auth",
+    BearerToken = "bearer_token"
+}
 export declare enum AuthStatus {
     Active = "active",
     Expired = "expired"
@@ -142,7 +154,7 @@ export interface KeyBasedParams {
      * `api_key` / `basic_auth` / `bearer_token`, so a connector offering more than one
      * cannot be resolved from the credentials alone.
      */
-    authType?: string;
+    authType?: AuthType | ConnectorAuthType;
 }
 export interface ConnectParams extends OAuthParams {
     /**
@@ -151,7 +163,7 @@ export interface ConnectParams extends OAuthParams {
      * {@link Application.auth_type_options}). If not provided, it defaults to `keybased`
      * when a payload is given, otherwise `oauth2`.
      */
-    type?: AuthType | string;
+    type?: AuthType | ConnectorAuthType;
 }
 /** The payload object for config. */
 export interface ConfigPayload {

--- a/refold.d.ts
+++ b/refold.d.ts
@@ -64,13 +64,7 @@ export interface Application {
     grant_type?: GrantType;
     /** The supported auth types for the application, and the fields required from the user to connect the application. */
     auth_type_options?: {
-        /**
-         * The fields required from the user to connect the application, keyed by auth
-         * type. Native apps use {@link AuthType} (`oauth2` / `keybased`); universal
-         * connectors key by their own supported types (`api_key`, `basic_auth`,
-         * `bearer_token`, `oauth2`) and may offer several for the user to choose from.
-         */
-        [authType: string]: InputField[];
+        [authType in AuthType | ConnectorAuthType]?: InputField[];
     };
     /** The list of connected accounts for this application */
     connected_accounts?: {

--- a/refold.d.ts
+++ b/refold.d.ts
@@ -120,12 +120,6 @@ export interface OAuthParams {
     /** The key value pairs of auth data. */
     payload?: Record<string, string>;
     /**
-     * The connector kind (from the app object's {@link Application.kind}). Universal
-     * connectors authenticate through their own endpoints, so pass this to skip the
-     * lookup. Omit it and the SDK resolves the kind from the app itself.
-     */
-    kind?: ConnectorKind;
-    /**
      * The application's OAuth grant (from the app object). Pass
      * {@link GrantType.ClientCredentials} for machine-to-machine connectors so
      * their fields are submitted to the server and no browser window is opened.
@@ -142,11 +136,6 @@ export interface KeyBasedParams {
     slug: string;
     /** The key value pairs of auth data. */
     payload?: Record<string, string>;
-    /**
-     * The connector kind (from the app object's {@link Application.kind}). Pass it to
-     * skip the lookup; omit it and the SDK resolves the kind from the app itself.
-     */
-    kind?: ConnectorKind;
     /**
      * The auth type being submitted, as named by the application's
      * {@link Application.auth_type_options}. Universal connectors distinguish
@@ -450,16 +439,6 @@ declare class Refold {
      * @returns {Promise<Application[]>} The list of applications.
      */
     getApps(): Promise<Application[]>;
-    /** Base path for a universal connector's own auth endpoints. */
-    private universalConnectorUrl;
-    /**
-     * Whether a slug is a universal connector. Trusts an explicitly supplied `kind`
-     * (no request); otherwise resolves it from the app. A failed lookup falls back to
-     * `false` so an unrelated outage can't turn a native connect into a wrong-endpoint
-     * call — the native path then reports the real error.
-     * @private
-     */
-    private isUniversalConnector;
     /**
      * Starts the connect flow for the specified application against `/integrate`.
      *
@@ -507,15 +486,14 @@ declare class Refold {
      * @returns A promise that resolves to true if the connection was successful, otherwise false.
      * @throws Throws an error if the authentication type is invalid or the connection fails.
      */
-    connect({ slug, type, payload, grantType, kind, autoClose, timeout, }: ConnectParams): Promise<boolean>;
+    connect({ slug, type, payload, grantType, autoClose, timeout, }: ConnectParams): Promise<boolean>;
     /**
      * Disconnect the specified application and remove any associated data from Refold.
      * @param {String} slug The application slug.
      * @param {AuthType} [type] The authentication type to use. If not provided, it'll remove all the connected accounts.
-     * @param {ConnectorKind} [kind] The connector kind (from the app object). Pass it to skip the lookup.
      * @returns {Promise<unknown>}
      */
-    disconnect(slug: string, type?: AuthType, kind?: ConnectorKind): Promise<unknown>;
+    disconnect(slug: string, type?: AuthType): Promise<unknown>;
     /**
      * Returns the specified config, or creates one if it doesn't exist.
      * @param {ConfigPayload} payload The payload object for config.

--- a/refold.js
+++ b/refold.js
@@ -148,6 +148,30 @@ class Refold {
             return data;
         });
     }
+    /** Base path for a universal connector's own auth endpoints. */
+    universalConnectorUrl(slug) {
+        return `${this.baseUrl}/api/v1/auth-service/f-sdk/universal-connector/${encodeURIComponent(slug)}`;
+    }
+    /**
+     * Whether a slug is a universal connector. Trusts an explicitly supplied `kind`
+     * (no request); otherwise resolves it from the app. A failed lookup falls back to
+     * `false` so an unrelated outage can't turn a native connect into a wrong-endpoint
+     * call — the native path then reports the real error.
+     * @private
+     */
+    isUniversalConnector(slug, kind) {
+        return __awaiter(this, void 0, void 0, function* () {
+            if (kind)
+                return kind === "universal_connector";
+            try {
+                const app = yield this.getApp(slug);
+                return (app === null || app === void 0 ? void 0 : app.kind) === "universal_connector";
+            }
+            catch (_a) {
+                return false;
+            }
+        });
+    }
     /**
      * Starts the connect flow for the specified application against `/integrate`.
      *
@@ -163,9 +187,11 @@ class Refold {
      * @param {GrantType} [grant] The application's OAuth grant. Omit for redirect grants.
      * @returns {Promise<{auth_url?: string, connected?: boolean}>} The server response.
      */
-    integrate(slug, params, grant) {
+    integrate(slug, params, grant, kind) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = `${this.baseUrl}/api/v1/${slug}/integrate`;
+            const url = (yield this.isUniversalConnector(slug, kind))
+                ? `${this.universalConnectorUrl(slug)}/integrate`
+                : `${this.baseUrl}/api/v1/${slug}/integrate`;
             const res = grant === GrantType.ClientCredentials
                 ? yield fetch(url, {
                     method: "POST",
@@ -198,8 +224,8 @@ class Refold {
      * @returns {Promise<Boolean>} Whether the user authenticated.
      */
     oauth(_a) {
-        return __awaiter(this, arguments, void 0, function* ({ slug, payload, grantType, autoClose = true, timeout = DEFAULT_CONNECT_TIMEOUT, }) {
-            const data = yield this.integrate(slug, payload, grantType);
+        return __awaiter(this, arguments, void 0, function* ({ slug, payload, grantType, kind, autoClose = true, timeout = DEFAULT_CONNECT_TIMEOUT, }) {
+            const data = yield this.integrate(slug, payload, grantType, kind);
             // No auth_url ⇒ the server completed the connection without a redirect
             // (client-credentials / M2M); report the outcome it gives us. A response
             // with neither an auth_url nor a connection result is unexpected — surface
@@ -278,8 +304,12 @@ class Refold {
      * @returns {Promise<Boolean>} Whether the auth data was saved successfully.
      */
     keybased(_a) {
-        return __awaiter(this, arguments, void 0, function* ({ slug, payload, }) {
-            const res = yield fetch(`${this.baseUrl}/api/v2/app/${slug}/save`, {
+        return __awaiter(this, arguments, void 0, function* ({ slug, payload, kind, }) {
+            // Universal connectors store credentials through their own endpoint.
+            const url = (yield this.isUniversalConnector(slug, kind))
+                ? `${this.universalConnectorUrl(slug)}/save-credentials`
+                : `${this.baseUrl}/api/v2/app/${slug}/save`;
+            const res = yield fetch(url, {
                 method: "POST",
                 headers: {
                     authorization: `Bearer ${this.token}`,
@@ -308,20 +338,20 @@ class Refold {
      * @throws Throws an error if the authentication type is invalid or the connection fails.
      */
     connect(_a) {
-        return __awaiter(this, arguments, void 0, function* ({ slug, type, payload, grantType, autoClose = true, timeout = DEFAULT_CONNECT_TIMEOUT, }) {
+        return __awaiter(this, arguments, void 0, function* ({ slug, type, payload, grantType, kind, autoClose = true, timeout = DEFAULT_CONNECT_TIMEOUT, }) {
             switch (type) {
                 case AuthType.OAuth2:
-                    return this.oauth({ slug, payload, grantType, autoClose, timeout });
+                    return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
                 case AuthType.KeyBased:
-                    return this.keybased({ slug, payload });
+                    return this.keybased({ slug, payload, kind });
                 default:
                     // client-credentials (M2M) is OAuth2 but carries a payload, so it
                     // must not be mistaken for a key-based connect.
                     if (grantType === GrantType.ClientCredentials)
-                        return this.oauth({ slug, payload, grantType, autoClose, timeout });
+                        return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
                     if (payload)
-                        return this.keybased({ slug, payload });
-                    return this.oauth({ slug, grantType, autoClose, timeout });
+                        return this.keybased({ slug, payload, kind });
+                    return this.oauth({ slug, grantType, kind, autoClose, timeout });
             }
         });
     }
@@ -329,16 +359,26 @@ class Refold {
      * Disconnect the specified application and remove any associated data from Refold.
      * @param {String} slug The application slug.
      * @param {AuthType} [type] The authentication type to use. If not provided, it'll remove all the connected accounts.
+     * @param {ConnectorKind} [kind] The connector kind (from the app object). Pass it to skip the lookup.
      * @returns {Promise<unknown>}
      */
-    disconnect(slug, type) {
+    disconnect(slug, type, kind) {
         return __awaiter(this, void 0, void 0, function* () {
-            const res = yield fetch(`${this.baseUrl}/api/v1/linked-acc/integration/${slug}${type ? `?auth_type=${type}` : ""}`, {
-                method: "DELETE",
-                headers: {
-                    authorization: `Bearer ${this.token}`,
-                },
-            });
+            // Universal connectors revoke through their own endpoint.
+            const isConnector = yield this.isUniversalConnector(slug, kind);
+            const res = isConnector
+                ? yield fetch(`${this.universalConnectorUrl(slug)}/revoke`, {
+                    method: "POST",
+                    headers: {
+                        authorization: `Bearer ${this.token}`,
+                    },
+                })
+                : yield fetch(`${this.baseUrl}/api/v1/linked-acc/integration/${slug}${type ? `?auth_type=${type}` : ""}`, {
+                    method: "DELETE",
+                    headers: {
+                        authorization: `Bearer ${this.token}`,
+                    },
+                });
             if (res.status >= 400 && res.status < 600) {
                 const error = yield res.json();
                 throw error;

--- a/refold.js
+++ b/refold.js
@@ -148,30 +148,6 @@ class Refold {
             return data;
         });
     }
-    /** Base path for a universal connector's own auth endpoints. */
-    universalConnectorUrl(slug) {
-        return `${this.baseUrl}/api/v1/auth-service/f-sdk/universal-connector/${encodeURIComponent(slug)}`;
-    }
-    /**
-     * Whether a slug is a universal connector. Trusts an explicitly supplied `kind`
-     * (no request); otherwise resolves it from the app. A failed lookup falls back to
-     * `false` so an unrelated outage can't turn a native connect into a wrong-endpoint
-     * call — the native path then reports the real error.
-     * @private
-     */
-    isUniversalConnector(slug, kind) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (kind)
-                return kind === "universal_connector";
-            try {
-                const app = yield this.getApp(slug);
-                return (app === null || app === void 0 ? void 0 : app.kind) === "universal_connector";
-            }
-            catch (_a) {
-                return false;
-            }
-        });
-    }
     /**
      * Starts the connect flow for the specified application against `/integrate`.
      *
@@ -187,11 +163,9 @@ class Refold {
      * @param {GrantType} [grant] The application's OAuth grant. Omit for redirect grants.
      * @returns {Promise<{auth_url?: string, connected?: boolean}>} The server response.
      */
-    integrate(slug, params, grant, kind) {
+    integrate(slug, params, grant) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = (yield this.isUniversalConnector(slug, kind))
-                ? `${this.universalConnectorUrl(slug)}/integrate`
-                : `${this.baseUrl}/api/v1/${slug}/integrate`;
+            const url = `${this.baseUrl}/api/v1/${slug}/integrate`;
             const res = grant === GrantType.ClientCredentials
                 ? yield fetch(url, {
                     method: "POST",
@@ -224,8 +198,8 @@ class Refold {
      * @returns {Promise<Boolean>} Whether the user authenticated.
      */
     oauth(_a) {
-        return __awaiter(this, arguments, void 0, function* ({ slug, payload, grantType, kind, autoClose = true, timeout = DEFAULT_CONNECT_TIMEOUT, }) {
-            const data = yield this.integrate(slug, payload, grantType, kind);
+        return __awaiter(this, arguments, void 0, function* ({ slug, payload, grantType, autoClose = true, timeout = DEFAULT_CONNECT_TIMEOUT, }) {
+            const data = yield this.integrate(slug, payload, grantType);
             // No auth_url ⇒ the server completed the connection without a redirect
             // (client-credentials / M2M); report the outcome it gives us. A response
             // with neither an auth_url nor a connection result is unexpected — surface
@@ -304,26 +278,19 @@ class Refold {
      * @returns {Promise<Boolean>} Whether the auth data was saved successfully.
      */
     keybased(_a) {
-        return __awaiter(this, arguments, void 0, function* ({ slug, payload, kind, authType, }) {
-            // Universal connectors store credentials through their own endpoint, and it
-            // takes a different body: the auth type is explicit (a connector may offer
-            // several key-based types) and the credentials are nested rather than spread.
-            const isConnector = yield this.isUniversalConnector(slug, kind);
-            const url = isConnector
-                ? `${this.universalConnectorUrl(slug)}/save-credentials`
-                : `${this.baseUrl}/api/v2/app/${slug}/save`;
-            const res = yield fetch(url, {
+        return __awaiter(this, arguments, void 0, function* ({ slug, payload, authType, }) {
+            // A connector offering several key-based types needs to be told which one; the generic
+            // `keybased` is not one of them, so it is not forwarded and an application's body stays
+            // exactly the credentials it always was. A connector with a single key-based type has
+            // it inferred server-side.
+            const connectorAuthType = authType && authType !== AuthType.KeyBased ? authType : undefined;
+            const res = yield fetch(`${this.baseUrl}/api/v2/app/${slug}/save`, {
                 method: "POST",
                 headers: {
                     authorization: `Bearer ${this.token}`,
                     "content-type": "application/json",
                 },
-                body: isConnector
-                    ? JSON.stringify({
-                        auth_type: authType !== null && authType !== void 0 ? authType : AuthType.KeyBased,
-                        credentials: payload !== null && payload !== void 0 ? payload : {},
-                    })
-                    : JSON.stringify(Object.assign({}, payload)),
+                body: JSON.stringify(Object.assign(Object.assign({}, payload), (connectorAuthType ? { auth_type: connectorAuthType } : {}))),
             });
             if (res.status >= 400 && res.status < 600) {
                 const error = yield res.json();
@@ -346,20 +313,20 @@ class Refold {
      * @throws Throws an error if the authentication type is invalid or the connection fails.
      */
     connect(_a) {
-        return __awaiter(this, arguments, void 0, function* ({ slug, type, payload, grantType, kind, autoClose = true, timeout = DEFAULT_CONNECT_TIMEOUT, }) {
+        return __awaiter(this, arguments, void 0, function* ({ slug, type, payload, grantType, autoClose = true, timeout = DEFAULT_CONNECT_TIMEOUT, }) {
             switch (type) {
                 case AuthType.OAuth2:
-                    return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
+                    return this.oauth({ slug, payload, grantType, autoClose, timeout });
                 case AuthType.KeyBased:
-                    return this.keybased({ slug, payload, kind, authType: type });
+                    return this.keybased({ slug, payload, authType: type });
                 default:
                     // client-credentials (M2M) is OAuth2 but carries a payload, so it
                     // must not be mistaken for a key-based connect.
                     if (grantType === GrantType.ClientCredentials)
-                        return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
+                        return this.oauth({ slug, payload, grantType, autoClose, timeout });
                     if (payload)
-                        return this.keybased({ slug, payload, kind, authType: type });
-                    return this.oauth({ slug, grantType, kind, autoClose, timeout });
+                        return this.keybased({ slug, payload, authType: type });
+                    return this.oauth({ slug, grantType, autoClose, timeout });
             }
         });
     }
@@ -367,26 +334,16 @@ class Refold {
      * Disconnect the specified application and remove any associated data from Refold.
      * @param {String} slug The application slug.
      * @param {AuthType} [type] The authentication type to use. If not provided, it'll remove all the connected accounts.
-     * @param {ConnectorKind} [kind] The connector kind (from the app object). Pass it to skip the lookup.
      * @returns {Promise<unknown>}
      */
-    disconnect(slug, type, kind) {
+    disconnect(slug, type) {
         return __awaiter(this, void 0, void 0, function* () {
-            // Universal connectors revoke through their own endpoint.
-            const isConnector = yield this.isUniversalConnector(slug, kind);
-            const res = isConnector
-                ? yield fetch(`${this.universalConnectorUrl(slug)}/revoke`, {
-                    method: "POST",
-                    headers: {
-                        authorization: `Bearer ${this.token}`,
-                    },
-                })
-                : yield fetch(`${this.baseUrl}/api/v1/linked-acc/integration/${slug}${type ? `?auth_type=${type}` : ""}`, {
-                    method: "DELETE",
-                    headers: {
-                        authorization: `Bearer ${this.token}`,
-                    },
-                });
+            const res = yield fetch(`${this.baseUrl}/api/v1/linked-acc/integration/${slug}${type ? `?auth_type=${type}` : ""}`, {
+                method: "DELETE",
+                headers: {
+                    authorization: `Bearer ${this.token}`,
+                },
+            });
             if (res.status >= 400 && res.status < 600) {
                 const error = yield res.json();
                 throw error;

--- a/refold.js
+++ b/refold.js
@@ -23,12 +23,25 @@ var __rest = (this && this.__rest) || function (s, e) {
     return t;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Refold = exports.GrantType = exports.AuthStatus = exports.AuthType = void 0;
+exports.Refold = exports.GrantType = exports.AuthStatus = exports.ConnectorAuthType = exports.AuthType = void 0;
 var AuthType;
 (function (AuthType) {
     AuthType["OAuth2"] = "oauth2";
     AuthType["KeyBased"] = "keybased";
 })(AuthType || (exports.AuthType = AuthType = {}));
+/**
+ * The auth types a universal connector can offer, as keyed in
+ * {@link Application.auth_type_options}. A native application is only ever an
+ * {@link AuthType}; a connector names its own and may support several, so the caller has
+ * to say which one it is submitting.
+ */
+var ConnectorAuthType;
+(function (ConnectorAuthType) {
+    ConnectorAuthType["OAuth2"] = "oauth2";
+    ConnectorAuthType["ApiKey"] = "api_key";
+    ConnectorAuthType["BasicAuth"] = "basic_auth";
+    ConnectorAuthType["BearerToken"] = "bearer_token";
+})(ConnectorAuthType || (exports.ConnectorAuthType = ConnectorAuthType = {}));
 var AuthStatus;
 (function (AuthStatus) {
     AuthStatus["Active"] = "active";

--- a/refold.js
+++ b/refold.js
@@ -304,9 +304,12 @@ class Refold {
      * @returns {Promise<Boolean>} Whether the auth data was saved successfully.
      */
     keybased(_a) {
-        return __awaiter(this, arguments, void 0, function* ({ slug, payload, kind, }) {
-            // Universal connectors store credentials through their own endpoint.
-            const url = (yield this.isUniversalConnector(slug, kind))
+        return __awaiter(this, arguments, void 0, function* ({ slug, payload, kind, authType, }) {
+            // Universal connectors store credentials through their own endpoint, and it
+            // takes a different body: the auth type is explicit (a connector may offer
+            // several key-based types) and the credentials are nested rather than spread.
+            const isConnector = yield this.isUniversalConnector(slug, kind);
+            const url = isConnector
                 ? `${this.universalConnectorUrl(slug)}/save-credentials`
                 : `${this.baseUrl}/api/v2/app/${slug}/save`;
             const res = yield fetch(url, {
@@ -315,7 +318,12 @@ class Refold {
                     authorization: `Bearer ${this.token}`,
                     "content-type": "application/json",
                 },
-                body: JSON.stringify(Object.assign({}, payload)),
+                body: isConnector
+                    ? JSON.stringify({
+                        auth_type: authType !== null && authType !== void 0 ? authType : AuthType.KeyBased,
+                        credentials: payload !== null && payload !== void 0 ? payload : {},
+                    })
+                    : JSON.stringify(Object.assign({}, payload)),
             });
             if (res.status >= 400 && res.status < 600) {
                 const error = yield res.json();
@@ -343,14 +351,14 @@ class Refold {
                 case AuthType.OAuth2:
                     return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
                 case AuthType.KeyBased:
-                    return this.keybased({ slug, payload, kind });
+                    return this.keybased({ slug, payload, kind, authType: type });
                 default:
                     // client-credentials (M2M) is OAuth2 but carries a payload, so it
                     // must not be mistaken for a key-based connect.
                     if (grantType === GrantType.ClientCredentials)
                         return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
                     if (payload)
-                        return this.keybased({ slug, payload, kind });
+                        return this.keybased({ slug, payload, kind, authType: type });
                     return this.oauth({ slug, grantType, kind, autoClose, timeout });
             }
         });

--- a/refold.ts
+++ b/refold.ts
@@ -20,9 +20,18 @@ export enum GrantType {
 }
 
 /** An application in Refold. */
+/**
+ * What kind of connector an application is. Universal connectors are configured in
+ * Refold rather than shipped as native integrations, and authenticate through their
+ * own endpoints — {@link Refold.connect} and {@link Refold.disconnect} route on this.
+ */
+export type ConnectorKind = "native" | "custom" | "universal_connector";
+
 export interface Application {
     /** Application ID */
     app_id: string;
+    /** Whether this is a native app, a custom app, or a universal connector. */
+    kind?: ConnectorKind;
     /**The application name. */
     name: string;
     /**The application description. */
@@ -113,6 +122,12 @@ export interface OAuthParams {
     /** The key value pairs of auth data. */
     payload?: Record<string, string>;
     /**
+     * The connector kind (from the app object's {@link Application.kind}). Universal
+     * connectors authenticate through their own endpoints, so pass this to skip the
+     * lookup. Omit it and the SDK resolves the kind from the app itself.
+     */
+    kind?: ConnectorKind;
+    /**
      * The application's OAuth grant (from the app object). Pass
      * {@link GrantType.ClientCredentials} for machine-to-machine connectors so
      * their fields are submitted to the server and no browser window is opened.
@@ -130,6 +145,11 @@ export interface KeyBasedParams {
     slug: string;
     /** The key value pairs of auth data. */
     payload?: Record<string, string>;
+    /**
+     * The connector kind (from the app object's {@link Application.kind}). Pass it to
+     * skip the lookup; omit it and the SDK resolves the kind from the app itself.
+     */
+    kind?: ConnectorKind;
 }
 
 export interface ConnectParams extends OAuthParams {
@@ -536,6 +556,28 @@ class Refold {
         return data;
     }
 
+    /** Base path for a universal connector's own auth endpoints. */
+    private universalConnectorUrl(slug: string): string {
+        return `${this.baseUrl}/api/v1/auth-service/f-sdk/universal-connector/${encodeURIComponent(slug)}`;
+    }
+
+    /**
+     * Whether a slug is a universal connector. Trusts an explicitly supplied `kind`
+     * (no request); otherwise resolves it from the app. A failed lookup falls back to
+     * `false` so an unrelated outage can't turn a native connect into a wrong-endpoint
+     * call — the native path then reports the real error.
+     * @private
+     */
+    private async isUniversalConnector(slug: string, kind?: ConnectorKind): Promise<boolean> {
+        if (kind) return kind === "universal_connector";
+        try {
+            const app = await this.getApp(slug);
+            return app?.kind === "universal_connector";
+        } catch {
+            return false;
+        }
+    }
+
     /**
      * Starts the connect flow for the specified application against `/integrate`.
      *
@@ -555,8 +597,11 @@ class Refold {
         slug: string,
         params?: Record<string, string>,
         grant?: GrantType,
+        kind?: ConnectorKind,
     ): Promise<{ auth_url?: string; connected?: boolean }> {
-        const url = `${this.baseUrl}/api/v1/${slug}/integrate`;
+        const url = await this.isUniversalConnector(slug, kind)
+            ? `${this.universalConnectorUrl(slug)}/integrate`
+            : `${this.baseUrl}/api/v1/${slug}/integrate`;
         const res = grant === GrantType.ClientCredentials
             ? await fetch(url, {
                 method: "POST",
@@ -594,10 +639,11 @@ class Refold {
         slug,
         payload,
         grantType,
+        kind,
         autoClose = true,
         timeout = DEFAULT_CONNECT_TIMEOUT,
     }: OAuthParams): Promise<boolean> {
-        const data = await this.integrate(slug, payload, grantType);
+        const data = await this.integrate(slug, payload, grantType, kind);
 
         // No auth_url ⇒ the server completed the connection without a redirect
         // (client-credentials / M2M); report the outcome it gives us. A response
@@ -688,8 +734,13 @@ class Refold {
     private async keybased({
         slug,
         payload,
+        kind,
     }: KeyBasedParams): Promise<boolean> {
-        const res = await fetch(`${this.baseUrl}/api/v2/app/${slug}/save`, {
+        // Universal connectors store credentials through their own endpoint.
+        const url = await this.isUniversalConnector(slug, kind)
+            ? `${this.universalConnectorUrl(slug)}/save-credentials`
+            : `${this.baseUrl}/api/v2/app/${slug}/save`;
+        const res = await fetch(url, {
             method: "POST",
             headers: {
                 authorization: `Bearer ${this.token}`,
@@ -726,21 +777,22 @@ class Refold {
         type,
         payload,
         grantType,
+        kind,
         autoClose = true,
         timeout = DEFAULT_CONNECT_TIMEOUT,
     }: ConnectParams): Promise<boolean> {
         switch (type) {
             case AuthType.OAuth2:
-                return this.oauth({ slug, payload, grantType, autoClose, timeout });
+                return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
             case AuthType.KeyBased:
-                return this.keybased({ slug, payload });
+                return this.keybased({ slug, payload, kind });
             default:
                 // client-credentials (M2M) is OAuth2 but carries a payload, so it
                 // must not be mistaken for a key-based connect.
                 if (grantType === GrantType.ClientCredentials)
-                    return this.oauth({ slug, payload, grantType, autoClose, timeout });
-                if (payload) return this.keybased({ slug, payload });
-                return this.oauth({ slug, grantType, autoClose, timeout });
+                    return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
+                if (payload) return this.keybased({ slug, payload, kind });
+                return this.oauth({ slug, grantType, kind, autoClose, timeout });
         }
     }
 
@@ -748,10 +800,20 @@ class Refold {
      * Disconnect the specified application and remove any associated data from Refold.
      * @param {String} slug The application slug.
      * @param {AuthType} [type] The authentication type to use. If not provided, it'll remove all the connected accounts.
+     * @param {ConnectorKind} [kind] The connector kind (from the app object). Pass it to skip the lookup.
      * @returns {Promise<unknown>}
      */
-    public async disconnect(slug: string, type?: AuthType): Promise<unknown> {
-        const res = await fetch(`${this.baseUrl}/api/v1/linked-acc/integration/${slug}${type ? `?auth_type=${type}` : ""}`, {
+    public async disconnect(slug: string, type?: AuthType, kind?: ConnectorKind): Promise<unknown> {
+        // Universal connectors revoke through their own endpoint.
+        const isConnector = await this.isUniversalConnector(slug, kind);
+        const res = isConnector
+            ? await fetch(`${this.universalConnectorUrl(slug)}/revoke`, {
+                method: "POST",
+                headers: {
+                    authorization: `Bearer ${this.token}`,
+                },
+            })
+            : await fetch(`${this.baseUrl}/api/v1/linked-acc/integration/${slug}${type ? `?auth_type=${type}` : ""}`, {
             method: "DELETE",
             headers: {
                 authorization: `Bearer ${this.token}`,

--- a/refold.ts
+++ b/refold.ts
@@ -127,12 +127,6 @@ export interface OAuthParams {
     /** The key value pairs of auth data. */
     payload?: Record<string, string>;
     /**
-     * The connector kind (from the app object's {@link Application.kind}). Universal
-     * connectors authenticate through their own endpoints, so pass this to skip the
-     * lookup. Omit it and the SDK resolves the kind from the app itself.
-     */
-    kind?: ConnectorKind;
-    /**
      * The application's OAuth grant (from the app object). Pass
      * {@link GrantType.ClientCredentials} for machine-to-machine connectors so
      * their fields are submitted to the server and no browser window is opened.
@@ -150,11 +144,6 @@ export interface KeyBasedParams {
     slug: string;
     /** The key value pairs of auth data. */
     payload?: Record<string, string>;
-    /**
-     * The connector kind (from the app object's {@link Application.kind}). Pass it to
-     * skip the lookup; omit it and the SDK resolves the kind from the app itself.
-     */
-    kind?: ConnectorKind;
     /**
      * The auth type being submitted, as named by the application's
      * {@link Application.auth_type_options}. Universal connectors distinguish
@@ -573,28 +562,6 @@ class Refold {
         return data;
     }
 
-    /** Base path for a universal connector's own auth endpoints. */
-    private universalConnectorUrl(slug: string): string {
-        return `${this.baseUrl}/api/v1/auth-service/f-sdk/universal-connector/${encodeURIComponent(slug)}`;
-    }
-
-    /**
-     * Whether a slug is a universal connector. Trusts an explicitly supplied `kind`
-     * (no request); otherwise resolves it from the app. A failed lookup falls back to
-     * `false` so an unrelated outage can't turn a native connect into a wrong-endpoint
-     * call — the native path then reports the real error.
-     * @private
-     */
-    private async isUniversalConnector(slug: string, kind?: ConnectorKind): Promise<boolean> {
-        if (kind) return kind === "universal_connector";
-        try {
-            const app = await this.getApp(slug);
-            return app?.kind === "universal_connector";
-        } catch {
-            return false;
-        }
-    }
-
     /**
      * Starts the connect flow for the specified application against `/integrate`.
      *
@@ -614,11 +581,8 @@ class Refold {
         slug: string,
         params?: Record<string, string>,
         grant?: GrantType,
-        kind?: ConnectorKind,
     ): Promise<{ auth_url?: string; connected?: boolean }> {
-        const url = await this.isUniversalConnector(slug, kind)
-            ? `${this.universalConnectorUrl(slug)}/integrate`
-            : `${this.baseUrl}/api/v1/${slug}/integrate`;
+        const url = `${this.baseUrl}/api/v1/${slug}/integrate`;
         const res = grant === GrantType.ClientCredentials
             ? await fetch(url, {
                 method: "POST",
@@ -656,11 +620,10 @@ class Refold {
         slug,
         payload,
         grantType,
-        kind,
         autoClose = true,
         timeout = DEFAULT_CONNECT_TIMEOUT,
     }: OAuthParams): Promise<boolean> {
-        const data = await this.integrate(slug, payload, grantType, kind);
+        const data = await this.integrate(slug, payload, grantType);
 
         // No auth_url ⇒ the server completed the connection without a redirect
         // (client-credentials / M2M); report the outcome it gives us. A response
@@ -751,30 +714,23 @@ class Refold {
     private async keybased({
         slug,
         payload,
-        kind,
         authType,
     }: KeyBasedParams): Promise<boolean> {
-        // Universal connectors store credentials through their own endpoint, and it
-        // takes a different body: the auth type is explicit (a connector may offer
-        // several key-based types) and the credentials are nested rather than spread.
-        const isConnector = await this.isUniversalConnector(slug, kind);
-        const url = isConnector
-            ? `${this.universalConnectorUrl(slug)}/save-credentials`
-            : `${this.baseUrl}/api/v2/app/${slug}/save`;
-        const res = await fetch(url, {
+        // A connector offering several key-based types needs to be told which one; the generic
+        // `keybased` is not one of them, so it is not forwarded and an application's body stays
+        // exactly the credentials it always was. A connector with a single key-based type has
+        // it inferred server-side.
+        const connectorAuthType = authType && authType !== AuthType.KeyBased ? authType : undefined;
+        const res = await fetch(`${this.baseUrl}/api/v2/app/${slug}/save`, {
             method: "POST",
             headers: {
                 authorization: `Bearer ${this.token}`,
                 "content-type": "application/json",
             },
-            body: isConnector
-                ? JSON.stringify({
-                    auth_type: authType ?? AuthType.KeyBased,
-                    credentials: payload ?? {},
-                })
-                : JSON.stringify({
-                    ...payload,
-                }),
+            body: JSON.stringify({
+                ...payload,
+                ...(connectorAuthType ? { auth_type: connectorAuthType } : {}),
+            }),
         });
 
         if (res.status >= 400 && res.status < 600) {
@@ -803,22 +759,21 @@ class Refold {
         type,
         payload,
         grantType,
-        kind,
         autoClose = true,
         timeout = DEFAULT_CONNECT_TIMEOUT,
     }: ConnectParams): Promise<boolean> {
         switch (type) {
             case AuthType.OAuth2:
-                return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
+                return this.oauth({ slug, payload, grantType, autoClose, timeout });
             case AuthType.KeyBased:
-                return this.keybased({ slug, payload, kind, authType: type });
+                return this.keybased({ slug, payload, authType: type });
             default:
                 // client-credentials (M2M) is OAuth2 but carries a payload, so it
                 // must not be mistaken for a key-based connect.
                 if (grantType === GrantType.ClientCredentials)
-                    return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
-                if (payload) return this.keybased({ slug, payload, kind, authType: type });
-                return this.oauth({ slug, grantType, kind, autoClose, timeout });
+                    return this.oauth({ slug, payload, grantType, autoClose, timeout });
+                if (payload) return this.keybased({ slug, payload, authType: type });
+                return this.oauth({ slug, grantType, autoClose, timeout });
         }
     }
 
@@ -826,20 +781,10 @@ class Refold {
      * Disconnect the specified application and remove any associated data from Refold.
      * @param {String} slug The application slug.
      * @param {AuthType} [type] The authentication type to use. If not provided, it'll remove all the connected accounts.
-     * @param {ConnectorKind} [kind] The connector kind (from the app object). Pass it to skip the lookup.
      * @returns {Promise<unknown>}
      */
-    public async disconnect(slug: string, type?: AuthType, kind?: ConnectorKind): Promise<unknown> {
-        // Universal connectors revoke through their own endpoint.
-        const isConnector = await this.isUniversalConnector(slug, kind);
-        const res = isConnector
-            ? await fetch(`${this.universalConnectorUrl(slug)}/revoke`, {
-                method: "POST",
-                headers: {
-                    authorization: `Bearer ${this.token}`,
-                },
-            })
-            : await fetch(`${this.baseUrl}/api/v1/linked-acc/integration/${slug}${type ? `?auth_type=${type}` : ""}`, {
+    public async disconnect(slug: string, type?: AuthType): Promise<unknown> {
+        const res = await fetch(`${this.baseUrl}/api/v1/linked-acc/integration/${slug}${type ? `?auth_type=${type}` : ""}`, {
             method: "DELETE",
             headers: {
                 authorization: `Bearer ${this.token}`,

--- a/refold.ts
+++ b/refold.ts
@@ -57,8 +57,13 @@ export interface Application {
     grant_type?: GrantType;
     /** The supported auth types for the application, and the fields required from the user to connect the application. */
     auth_type_options?: {
-        /** The fields required from the user to connect the application. */
-        [key in AuthType]: InputField[];
+        /**
+         * The fields required from the user to connect the application, keyed by auth
+         * type. Native apps use {@link AuthType} (`oauth2` / `keybased`); universal
+         * connectors key by their own supported types (`api_key`, `basic_auth`,
+         * `bearer_token`, `oauth2`) and may offer several for the user to choose from.
+         */
+        [authType: string]: InputField[];
     };
     /** The list of connected accounts for this application */
     connected_accounts?: {
@@ -150,11 +155,23 @@ export interface KeyBasedParams {
      * skip the lookup; omit it and the SDK resolves the kind from the app itself.
      */
     kind?: ConnectorKind;
+    /**
+     * The auth type being submitted, as named by the application's
+     * {@link Application.auth_type_options}. Universal connectors distinguish
+     * `api_key` / `basic_auth` / `bearer_token`, so a connector offering more than one
+     * cannot be resolved from the credentials alone.
+     */
+    authType?: string;
 }
 
 export interface ConnectParams extends OAuthParams {
-    /** The authentication type to use. If not provided, it defaults to `keybased` if payload is provided, otherwise `oauth2`. */
-    type?: AuthType;
+    /**
+     * The authentication type to use — an {@link AuthType} for native applications, or
+     * one of a universal connector's own types (a key of
+     * {@link Application.auth_type_options}). If not provided, it defaults to `keybased`
+     * when a payload is given, otherwise `oauth2`.
+     */
+    type?: AuthType | string;
 }
 
 /** The payload object for config. */
@@ -735,9 +752,13 @@ class Refold {
         slug,
         payload,
         kind,
+        authType,
     }: KeyBasedParams): Promise<boolean> {
-        // Universal connectors store credentials through their own endpoint.
-        const url = await this.isUniversalConnector(slug, kind)
+        // Universal connectors store credentials through their own endpoint, and it
+        // takes a different body: the auth type is explicit (a connector may offer
+        // several key-based types) and the credentials are nested rather than spread.
+        const isConnector = await this.isUniversalConnector(slug, kind);
+        const url = isConnector
             ? `${this.universalConnectorUrl(slug)}/save-credentials`
             : `${this.baseUrl}/api/v2/app/${slug}/save`;
         const res = await fetch(url, {
@@ -746,9 +767,14 @@ class Refold {
                 authorization: `Bearer ${this.token}`,
                 "content-type": "application/json",
             },
-            body: JSON.stringify({
-                ...payload,
-            }),
+            body: isConnector
+                ? JSON.stringify({
+                    auth_type: authType ?? AuthType.KeyBased,
+                    credentials: payload ?? {},
+                })
+                : JSON.stringify({
+                    ...payload,
+                }),
         });
 
         if (res.status >= 400 && res.status < 600) {
@@ -785,13 +811,13 @@ class Refold {
             case AuthType.OAuth2:
                 return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
             case AuthType.KeyBased:
-                return this.keybased({ slug, payload, kind });
+                return this.keybased({ slug, payload, kind, authType: type });
             default:
                 // client-credentials (M2M) is OAuth2 but carries a payload, so it
                 // must not be mistaken for a key-based connect.
                 if (grantType === GrantType.ClientCredentials)
                     return this.oauth({ slug, payload, grantType, kind, autoClose, timeout });
-                if (payload) return this.keybased({ slug, payload, kind });
+                if (payload) return this.keybased({ slug, payload, kind, authType: type });
                 return this.oauth({ slug, grantType, kind, autoClose, timeout });
         }
     }

--- a/refold.ts
+++ b/refold.ts
@@ -73,10 +73,11 @@ export interface Application {
         /**
          * The fields required from the user to connect the application, keyed by auth
          * type. Native apps use {@link AuthType} (`oauth2` / `keybased`); universal
-         * connectors key by their own supported types (`api_key`, `basic_auth`,
-         * `bearer_token`, `oauth2`) and may offer several for the user to choose from.
+         * connectors key by their own {@link ConnectorAuthType} (`api_key`,
+         * `basic_auth`, `bearer_token`, `oauth2`) and may offer several for the user to
+         * choose from. Keys are optional because which ones appear depends on the kind.
          */
-        [authType: string]: InputField[];
+        [authType in AuthType | ConnectorAuthType]?: InputField[];
     };
     /** The list of connected accounts for this application */
     connected_accounts?: {

--- a/refold.ts
+++ b/refold.ts
@@ -7,6 +7,19 @@ export enum AuthType {
     KeyBased = "keybased",
 }
 
+/**
+ * The auth types a universal connector can offer, as keyed in
+ * {@link Application.auth_type_options}. A native application is only ever an
+ * {@link AuthType}; a connector names its own and may support several, so the caller has
+ * to say which one it is submitting.
+ */
+export enum ConnectorAuthType {
+    OAuth2 = "oauth2",
+    ApiKey = "api_key",
+    BasicAuth = "basic_auth",
+    BearerToken = "bearer_token",
+}
+
 export enum AuthStatus {
     Active = "active",
     Expired = "expired",
@@ -150,7 +163,7 @@ export interface KeyBasedParams {
      * `api_key` / `basic_auth` / `bearer_token`, so a connector offering more than one
      * cannot be resolved from the credentials alone.
      */
-    authType?: string;
+    authType?: AuthType | ConnectorAuthType;
 }
 
 export interface ConnectParams extends OAuthParams {
@@ -160,7 +173,7 @@ export interface ConnectParams extends OAuthParams {
      * {@link Application.auth_type_options}). If not provided, it defaults to `keybased`
      * when a payload is given, otherwise `oauth2`.
      */
-    type?: AuthType | string;
+    type?: AuthType | ConnectorAuthType;
 }
 
 /** The payload object for config. */


### PR DESCRIPTION
### Summary
Connecting a **Universal Connector** from the connect portal failed. Connectors authenticate through their own endpoints under `/api/v1/auth-service/f-sdk/universal-connector/:slug`, but `connect()`/`disconnect()` always called the native/custom app routes, so the request 404'd:

```
GET /api/v1/hubspot-crm/integrate
→ 404 {"message":"Application with app_type 'hubspot-crm' not found for org …"}

GET /api/v1/auth-service/f-sdk/universal-connector/hubspot-crm/integrate
→ 200 {"auth_url":"https://app.hubspot.com/oauth/authorize?…"}
```

The SDK had no notion of connectors at all — it already receives `kind` from `/api/v2/f-sdk/application` but never typed or used it.

`connect()` and `disconnect()` now route on the connector kind:

| flow | native / custom (unchanged) | universal connector |
|---|---|---|
| oauth | `/api/v1/${slug}/integrate` | `…/f-sdk/universal-connector/${slug}/integrate` |
| keybased | `/api/v2/app/${slug}/save` | `…/universal-connector/${slug}/save-credentials` |
| disconnect | `/api/v1/linked-acc/integration/${slug}` | `…/universal-connector/${slug}/revoke` |

Also adds the `kind` field to `Application` (the app list already returns it) and exports a `ConnectorKind` type.

### Approach
**Explicit kind, with lookup fallback.** Callers can pass `kind` (from the app object) on `connect()`/`disconnect()` to route with no extra request; when it's omitted the SDK resolves the kind itself via `getApp(slug)`. That keeps existing consumers working without a call-site change while letting the portal avoid the round trip.

A failed lookup falls back to the **native** path rather than guessing the connector route, so an unrelated outage can't turn a native connect into a wrong-endpoint call — the native path then surfaces the real error.

Rejected alternative: shimming the backend's custom-app catch-all (`/:slug/integrate`) to absorb connector slugs. That would have fixed every already-shipped SDK version without a release, but it conflates two distinct auth surfaces server-side; keeping the connector path separate in the SDK is the correct model.

Version bumped to 10.3.0 (additive feature, no breaking change); `refold.js`/`refold.d.ts` and docs regenerated.

### Test Plan
- [x] `npm run build` — compiles clean; `ConnectorKind`, `Application.kind` and the `kind` params appear in `refold.d.ts`; UC routing present in `refold.js`.
- [x] Verified against a live env that the connector endpoints this routes to return `200` with an `auth_url`, while the previously-called native route returns `404`.
- [ ] In the connect portal, connect an **OAuth** universal connector — the popup opens the provider and the connection completes.
- [ ] Connect a **key-based** connector (api_key / bearer_token) — credentials save via `save-credentials`.
- [ ] Disconnect a connector — it revokes and disappears from connected accounts.
- [ ] Regression: connect + disconnect a **native** app and a **custom** app — unchanged behaviour.
- [ ] Regression: omit `kind` on a connector connect — the SDK still routes correctly via its own lookup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for universal connector authentication and routing.
  - Connection and disconnection flows now support connector kind metadata.
  - Key-based authentication supports OAuth2, API key, basic, and bearer token options.
  - Added fallback routing when connector details cannot be resolved.
  - Expanded support for custom authentication types.

- **Documentation**
  - Updated public API documentation with the optional `kind` parameter for disconnection.

- **Chores**
  - Updated the package version to 10.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->